### PR TITLE
Fix fetch .env and add caching to fetch_commits

### DIFF
--- a/oss_stats/cache.py
+++ b/oss_stats/cache.py
@@ -1,0 +1,27 @@
+import json
+
+CACHE_FILE = "stats/stats.json"
+
+
+def load_cache():
+    try:
+        with open(CACHE_FILE, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_cache(cache):
+    with open(CACHE_FILE, "w") as f:
+        json.dump(cache, f, indent=4)
+
+
+def create_entry(stats, repo_name: str):
+    stats[repo_name] = {
+        "commits": 0,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    }

--- a/oss_stats/cli.py
+++ b/oss_stats/cli.py
@@ -19,7 +19,7 @@ def cli(option):
         console.print(f"{prs} total pull requests!")
     if option == "commits":
         commits = fetch_commits()
-        console.print(f"{sum(commits)} total commits!")
+        console.print(f"{sum(commits.values())} total commits!")
     if option == "issues":
         issues = fetch_issues()
         console.print(f"{sum(issues)} total issues")

--- a/oss_stats/cli.py
+++ b/oss_stats/cli.py
@@ -1,6 +1,6 @@
 import click
 from rich.console import Console
-from .github import fetch_repositories, fetch_prs, fetch_commits, fetch_issues
+from .stats import fetch_repositories, fetch_prs, fetch_commits, fetch_issues
 
 console = Console()
 

--- a/oss_stats/stats.py
+++ b/oss_stats/stats.py
@@ -1,30 +1,41 @@
 from github import Github
+from dotenv import load_dotenv
 import os
 
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "..", ".env"))
 token = os.getenv("GITHUB_TOKEN")
-github = Github(token)
+
+if not token:
+    raise Exception("No token present!")
+
+gh = Github(token)
+
+rate_limit = gh.get_rate_limit()
+print(rate_limit.core.remaining, rate_limit.core.limit)
+print(rate_limit.search.remaining, rate_limit.search.limit)
+
 
 org = "acmcsufoss"
 
 def fetch_repositories():
-    repos = github.get_organization(org).get_repos()
+    repos = gh.get_organization(org).get_repos()
     return [repo.name for repo in repos]
 
 
 def fetch_commits():
-    repos = github.get_organization(org).get_repos()
+    repos = gh.get_organization(org).get_repos()
     result = []
     for repo in repos:
         try:
             commits = repo.get_commits().totalCount
-        except Exception as e:
+        except Exception as _:
             commits = 0
         result.append(commits)
     return result
 
 
 def fetch_prs():
-    repos = github.get_organization(org).get_repos()
+    repos = gh.get_organization(org).get_repos()
     num_PRs = 0
     # Loops through each repo and counts PRs
     for repo in repos:
@@ -33,5 +44,5 @@ def fetch_prs():
 
 
 def fetch_issues():
-    repos = github.get_organization(org).get_repos()
+    repos = gh.get_organization(org).get_repos()
     return [repo.get_issues(state="all").totalCount for repo in repos]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -1,0 +1,378 @@
+{
+    "fullyhacks": {
+        "commits": 395,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acmcsuf.com-deno": {
+        "commits": 6,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "gallery": {
+        "commits": 12,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "docs": {
+        "commits": 81,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "form": {
+        "commits": 89,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "1st": {
+        "commits": 399,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "lc-dailies": {
+        "commits": 75,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "tldr": {
+        "commits": 22,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "api.acmcsuf.com": {
+        "commits": 84,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acm-server": {
+        "commits": 587,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "oss-stats": {
+        "commits": 20,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "shorter": {
+        "commits": 44,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "svelte-workshop": {
+        "commits": 17,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acmOpportunities": {
+        "commits": 77,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "dash.acmcsuf.com": {
+        "commits": 0,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "ai-hello-world": {
+        "commits": 11,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "crying-counter": {
+        "commits": 11,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acm-election": {
+        "commits": 0,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_fastapi": {
+        "commits": 2,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_sveltekit": {
+        "commits": 14,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_react_native": {
+        "commits": 5,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "clubannounce": {
+        "commits": 12,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acm-utterances": {
+        "commits": 1,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "trends": {
+        "commits": 4,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "i": {
+        "commits": 8,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "qb64_windows": {
+        "commits": 1,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "py-workshop": {
+        "commits": 2,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "go-workshop": {
+        "commits": 30,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "ts-workshop": {
+        "commits": 2,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "js-workshop": {
+        "commits": 11,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "sendlimiter": {
+        "commits": 41,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_flask_vercel": {
+        "commits": 21,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "api-workshop": {
+        "commits": 5,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "acmJane": {
+        "commits": 76,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "denokv-workshop": {
+        "commits": 3,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "perks": {
+        "commits": 5,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "boardd": {
+        "commits": 39,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "archive": {
+        "commits": 1,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    ".github": {
+        "commits": 2,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "triggers-nix": {
+        "commits": 0,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_data_science": {
+        "commits": 8,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_discord_python": {
+        "commits": 7,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "prisma-crud-examples": {
+        "commits": 12,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_html_css": {
+        "commits": 5,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "fullypack_fastify_solid": {
+        "commits": 5,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "qg": {
+        "commits": 47,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    },
+    "triggers": {
+        "commits": 250,
+        "issues": 0,
+        "pull_requests": 0,
+        "contributors": [],
+        "star_count": 0,
+        "last_updated": ""
+    }
+}


### PR DESCRIPTION
Key changes:
- Ensure we are looking at the correct path of the `.env` file (outside `oss_stats/`)
- Add caching logic to `fetch_commits` for testing
- Dump API responses in `stats/stats.json` with every repos

What to do next:
- Handle caching logic on every other API function
- Refetch for the latest updated repositories (6-month period)