### PR TITLE
set loadenv to refer to the parent directory of env

### DIFF
--- a/src/oss_stats/stats.py
+++ b/src/oss_stats/stats.py
@@ -19,10 +19,8 @@ from .const import (
 )
 from .cache import create_entry, load_cache, save_cache
 
-#first get the current directory
 currentDir = os.path.dirname(__file__)
 
-#we need parentDir to be able to read the .env file
 parentDir = os.path.basename(currentDir)
 
 load_dotenv(dotenv_path=os.path.join(parentDir, "..", ".env"))

--- a/src/oss_stats/stats.py
+++ b/src/oss_stats/stats.py
@@ -19,7 +19,14 @@ from .const import (
 )
 from .cache import create_entry, load_cache, save_cache
 
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "..", ".env"))
+#first get the current directory
+currentDir = os.path.dirname(__file__)
+
+#we need parentDir to be able to read the .env file
+parentDir = os.path.basename(currentDir)
+
+load_dotenv(dotenv_path=os.path.join(parentDir, "..", ".env"))
+print(os.path.join(parentDir, "..", ".env"))
 token = os.getenv("GITHUB_TOKEN")
 
 if not token:


### PR DESCRIPTION
Encountered an issue with the GITHUB_TOKEN environment variable not working. I just changed the loadenv so that it is now looking in the parent directory, allowing for the environment variable to be visible again. This should fix it.