### PR TITLE
Fix stars: read stargazers_count instead of paginating /stargazers

### DIFF
--- a/src/oss_stats/stats.py
+++ b/src/oss_stats/stats.py
@@ -68,8 +68,13 @@ def get_prs(repo: Repository) -> int:
 
 
 def get_stars(repo: Repository) -> int:
-    """Returns the number of stargazers (stars) for the repository"""
-    return repo.get_stargazers().totalCount
+    """Returns the number of stargazers (stars) for the repository
+
+    Reads stargazers_count from the repo payload rather than paginating
+    /stargazers, which returns 404 for most repos in this org and costs one
+    request per repo when it does work.
+    """
+    return repo.stargazers_count
 
 
 def get_contributors(repo: Repository) -> List[str]:


### PR DESCRIPTION
# Fix stars: read `stargazers_count` instead of paginating `/stargazers`

`oss-stats` has been reporting **7 total stars for the org when the real figure is 146**.
This is a one-line fix to `get_stars()`.

## What's wrong

`get_stars()` calls `repo.get_stargazers().totalCount`, which hits
`GET /repos/{owner}/{repo}/stargazers`. That endpoint returns 404 for 58 of the org's 59
repos. Only `oss-stats` itself succeeds.

It is server side, not a PyGithub artifact. Confirmed with raw HTTP against the same
token:

```
acmcsufoss/community      stargazers=404  repo=200  stargazers_count=1
acmcsufoss/oss-stats      stargazers=200  repo=200  stargazers_count=7
acmcsufoss/acmcsuf.com    stargazers=404  repo=200  stargazers_count=48
```

The `GithubException` is swallowed by the `except` in `fetch_res`, which substitutes the
`-1` default. So 58 of 59 repos have had `-1` written to the cache, and the aggregate
`"{sum} total stargazers!"` line has been summing a single repo.

## It also permanently defeats the cache

This is the part worth flagging beyond the wrong number. The cache reuse guard is:

```python
if cache[repo.name][res] != default_value and is_stale(repo):
```

Because the stored value *is* `default_value` (`-1`), the guard is never satisfied, so
stars re-fetches all 59 repos on every single run no matter how stale they are and no
matter what threshold is configured. In benchmarking on #55 stars cost 59 calls on both
the cold and the warm pass, the only resource showing zero improvement.

## The fix

`stargazers_count` is already in the repo payload returned by the org listing the tool
already performs, so reading it costs no additional request and cannot fail.

Measured across all 59 repos, counting real HTTP requests:

| approach | calls | succeeded | failed | total stars |
|---|---|---|---|---|
| `get_stargazers().totalCount` | 59 | 1 | 58 | 7 |
| `repo.stargazers_count` | 0 | 59 | 0 | 146 |

Where the old path did succeed, the two agree (1 of 1), so this is not trading one wrong
number for another. 31 of the 59 repos have at least one star.

End-to-end through `fetch_stars()` on a cleared cache: 59 repos returned, 146 total stars,
0 repos left holding `-1`, and 0 stars-specific calls. The 3 requests that run are the
shared org repo listing every resource already pays for.

## Scope

One function, no dependency changes, no behaviour change anywhere else. `ruff format
--check` and `ruff check` pass.

Independent of #55 and touches a different function in the same file, so the two can merge
in either order. Worth noting that this removes the 59-call floor that holds back the
reduction measured there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
