### PR TITLE
Fix dotenv lookup: search upward from cwd instead of relative to __file__

### DIFF
--- a/src/oss_stats/stats.py
+++ b/src/oss_stats/stats.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import List
 from github import Github, GithubException
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from datetime import datetime, timedelta, timezone
 from alive_progress import alive_bar
 from .error import error
@@ -19,7 +19,10 @@ from .const import (
 )
 from .cache import create_entry, load_cache, save_cache
 
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "..", ".env"))
+# Search upward from the working directory rather than relative to this file.
+# A __file__-relative path resolved to src/.env, which never exists, and would
+# point into site-packages once the package is pip-installed.
+load_dotenv(find_dotenv(usecwd=True))
 token = os.getenv("GITHUB_TOKEN")
 
 if not token:


### PR DESCRIPTION
# Fix dotenv lookup: search upward from cwd instead of relative to `__file__`

Following the README setup instructions exactly produces `The GITHUB_TOKEN environment
variable is unset!` and exit 1. This one-line fix makes a repo-root dotenv file actually
load.

## What's wrong

```python
load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "..", ".env"))
```

`__file__` is `src/oss_stats/stats.py`, so `dirname` is `src/oss_stats` and a single `..`
lands on `src`. The path resolves to `src/.env`. That file does not exist and never has.
The documented location, per the README, is the repo root, which is one level further up.

The failure is silent. Passing an explicit `dotenv_path` disables python-dotenv's search
fallback, so it finds nothing, sets nothing, and the error only surfaces later as a
missing token. Anyone who has this working today is relying on `GITHUB_TOKEN` already
being exported in their shell, not on the dotenv file the README tells them to create.

## The fix

```python
load_dotenv(find_dotenv(usecwd=True))
```

`find_dotenv(usecwd=True)` walks up from the working directory until it finds the file.

I chose this over just adding a second `..` deliberately. A `__file__`-relative path is
wrong in a way that extra `..` segments cannot fix: once the package is pip-installed,
`__file__` points into `site-packages` and no relative path from there reaches the user's
config. Since `pyproject.toml` already declares a `project.scripts` entry point and PyPI
packaging landed recently, installed usage is a real path, not a hypothetical.

An already-exported `GITHUB_TOKEN` still takes priority, because `load_dotenv` does not
override existing environment variables.

## Verification

With `GITHUB_TOKEN` explicitly unset in the environment, so the only possible source is
the dotenv file:

| run from | result |
|---|---|
| repo root | import OK, token loaded |
| `src/oss_stats/` subdirectory | import OK, token loaded (walked up) |
| unrelated directory (`/tmp`) | clean `GITHUB_TOKEN is unset` error, exit 1 |

The first row is the case that is broken on `main`. It reproduced earlier in this work:
running the tooling from the repo root with a valid config file present aborted
immediately with the unset-token error.

The third row confirms the fix does not paper over genuinely missing configuration. The
existing error path is preserved.

## Scope

One import and one line, no dependency changes, no behaviour change when the token is
already exported. `ruff format --check` and `ruff check` pass.

Independent of #55 and #56. All three touch different regions of `stats.py` and can merge
in any order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
